### PR TITLE
Added Cen-Tec Quick-Connect adapter option for connector 2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ any air leaks that might reduce the suction power of your vacuum.
 
 ## Connection types
 
-Three different types of connections are possible to maximize the number of
+Four different types of connections are possible to maximize the number of
 applications possible.
 
 ### Hose connection
@@ -53,6 +53,11 @@ Ideally, the flange should be created with a small recess to accept the ring.
 The most optimal solution would be to print the ring in flexible material (TPU).
 
 Although, this does not appear to be required to have a good suction.
+
+#### CTS Cen-Tec Quick-connect
+An connector 2 adapter for CTS Cen-Tec quick-connect hoses (see https://www.centecsystems.com/quick-click-dust-collection/). 
+The stubby Cen-Tec adapter comes from an existing STL model (https://www.thingiverse.com/thing:4739202), but had to be remixed in Meshmixer to resolve a non-manifold fault in the STL - the resultant new STL is quite large and has been ZIP'd for Github.
+A better solution would be to design the Cen-Tec adapter from scratch in OpenSCAD but this solution works OK for now.
 
 #### Main settings
 **Changing any of the settings** (diameter, magnet size, alignment ring...)

--- a/vacuum-hose-adapter-modules.scad
+++ b/vacuum-hose-adapter-modules.scad
@@ -1409,6 +1409,12 @@ module HoseAdapter(
             nozzleChamferPercentage = connector2NozzleChamferPercentage,
             nozzleChamferAngle = connector2NozzleChamferAngle);
         }
+
+        if(connector2Style == "Cen-Tec")
+        {
+          echo("Cen-tec end connector 2")
+          import("Cen-Tec_Systems_Stubby_1.5.stl");
+        }
       }
     }
   }

--- a/vacuum-hose-adapter-openscad.scad
+++ b/vacuum-hose-adapter-openscad.scad
@@ -97,7 +97,7 @@ Transition_Base_Angle=0;
 /* [Connector 2] */
 //Wall thickness
 End2_Wall_Thickness = 2; //0.01
-End2_Style="nozzle"; // [mag: Magnetic Flange, hose: Hose connector, nozzle: Nozzle attachement]
+End2_Style="nozzle"; // [mag: Magnetic Flange, hose: Hose connector, nozzle: Nozzle attachment, Cen-Tec: CTS Cen-Tec Quick Connect]
 // Is the measurement the adapter's outside or inside diameter?
 End2_Measurement = "outer"; //[inner, outer]
 // End 2 diameter of the adapter (mm)


### PR DESCRIPTION
Added new connector 2 adapter for Cen-tec Quick-Connect hoses which is a quick-release hose solution for workshop tools.