### PR TITLE
Decreased wall thickness on slots for dw735 connector

### DIFF
--- a/vacuum-hose-adapter-modules.scad
+++ b/vacuum-hose-adapter-modules.scad
@@ -1092,7 +1092,7 @@ module Dw735Connector(
   slotLength = 16;  
   slotOffset1 = 7.5;  
   slotOffset2 = 9;  
-  fixedPinLength = 4.5;
+  fixedPinLength = 4.1;
   
   _connectorCount = max(1,connectorCount);
   
@@ -1113,7 +1113,7 @@ module Dw735Connector(
         StraightPipe (
           diameter = innerEndDiameter+wallThickness*2,
           length = length,
-          wallThickness = fixedPinLength);
+          wallThickness = fixedPinLength - 1.5);
         
         for (rotation = [0:_connectorCount-1])
         {


### PR DESCRIPTION
Decreased fixedPinLength and wallThikness for the slots on the dw735 connector.

![IMG_4530](https://github.com/ostat/vacuum-hose-adapter-openscad/assets/1028540/a1c42541-669a-4e02-b25e-1fa82a6a8114)

![IMG_4532](https://github.com/ostat/vacuum-hose-adapter-openscad/assets/1028540/2c50bc55-30e2-47de-bdb4-232c5eb73f9d)

Fixes #8