### PR TITLE
Fix flat-topped internal hose thread teeth when tooth height < pitch

### DIFF
--- a/modules/modules_threads.scad
+++ b/modules/modules_threads.scad
@@ -40,17 +40,32 @@ module InternalHoseThread(
   tooth_angle=30,
   tooth_height=0,
   reverse_thread = false) {
+
+  // Same bore sizing as ScrewHole.
+  cut_diam = 1.01*diameter + 1.25*tolerance;
+  _pitch = (pitch==0) ? ThreadPitch(cut_diam) : pitch;
+  _tooth_height = (tooth_height==0) ? _pitch : min(tooth_height, _pitch);
+
+  // ScrewHole's cut profile is flat at the root radius, which truncates the
+  // material teeth flat when tooth_height < pitch. Cutting with a full-height
+  // (pointy) thread enlarged by 'shift', clipped back to the intended major
+  // radius, keeps the teeth pointy at the requested height and flank angle.
+  shift = (_pitch - _tooth_height) / (2*tan(tooth_angle));
+  extra_height = 0.001 * height;
+
   mirror(reverse_thread ? [0,0,0] :[1,0,0])
-  ScrewHole(
-    outer_diam=diameter,
-    height=height,
-    tolerance=tolerance,
-    position=position,
-    rotation=rotation,
-    pitch=pitch,
-    tooth_angle=tooth_angle,
-    tooth_height=tooth_height)
+  difference() {
     cylinder(h=height, r=diameter/2+wallThickness);
+    translate(position)
+      rotate(rotation)
+      translate([0, 0, -extra_height/2])
+      intersection() {
+        ScrewThread(cut_diam + 2*shift, height + extra_height,
+          pitch=_pitch, tooth_angle=tooth_angle, tolerance=tolerance);
+        // ScrewThread's crest radius for cut_diam, shrinkage correction included.
+        cylinder(h=height + extra_height, r=(cut_diam + 0.25*tolerance)/2);
+      }
+  }
 }
 
 // create an external thread outside a hose (like a bolt)


### PR DESCRIPTION
**Problem:** Internal hose thread teeth get flat tips instead of shrinking when the tooth height < pitch. For example, in the photo below, I configured a 50mm ID hose connector with threads enabled and set at a 5mm pitch and 30 degree angle. The left image shows the connector with a 5mm tooth height while the right has a 3mm tooth height. As you can see, the teeth on the right side are flat instead of pointy and uniformly reduced in size. 
<img width="2000" height="997" alt="image" src="https://github.com/user-attachments/assets/949f2a05-1229-4fd1-91e6-b1a77d228467" />

**Cause:** ScrewHole cuts internal threads with a ScrewThread whose profile leaves the part of each pitch not covered by the tooth as a flat at the root radius. When tooth_height < pitch, that flat truncates the tips of the remaining material teeth instead of shrinking them.

**Fix:** InternalHoseThread now cuts with an unmodified full-height (pointy) ScrewThread enlarged radially by the depth the tooth lost, then clipped back to the intended major radius with an intersection. The clipped crests become the flats between teeth on the bore wall, so the material teeth shrink while staying pointy, with the requested tooth height and flank angle. Tooth heights larger than the pitch (previously degenerate, self-overlapping geometry) are now clamped to the pitch and behave like the default. The third-party threads.scad library is unchanged. 

**Testing:** Verified with a full render and an actual print that mated correctly to my hose. The photo below shows the same cross-section view and configuration as above (50mm ID hose connector with threads enabled and set at a 5mm pitch and 30 degree angle) with a 3mm tooth height. As you can see, the teeth now shrink uniformly while keeping their pointed profile.
<img width="873" height="886" alt="image" src="https://github.com/user-attachments/assets/0299bc37-1506-4aa7-8dd4-8f1ad5920fa6" />

_Note:_ The combined/ files are not included since they're regenerated by the auto-combine workflow on merge. Feel free to make any changes you see fit to the code before merging. For transparency sake, I want to note that I used Claude to help me figure this out, since I'm not a programmer. However, I tried my best to test/verify/confirm these changes and reduce any unnecessary alterations before submitting this PR. 