### PR TITLE
Constrain external hose thread tooth height to the pitch

### DIFF
--- a/modules/modules_threads.scad
+++ b/modules/modules_threads.scad
@@ -80,7 +80,7 @@ module ExternalHoseThread(
         tip_height=tip_height == 0 ? ThreadPitch(diameter) : tip_height,
         pitch=pitch,
         tooth_angle=tooth_angle,
-        tooth_height=tooth_height,
+        tooth_height=min(tooth_height, pitch==0 ? ThreadPitch(diameter+wallThickness*2) : pitch),
         tip_min_fract=tip_min_fract,
         referenceThreadOuter= false);
 


### PR DESCRIPTION
**Problem:** I noticed that when the thread tooth height is set > pitch, the script produces self-overlapping, impossible geometry. Example:
<img width="713" height="440" alt="Screenshot 2026-07-11 202613" src="https://github.com/user-attachments/assets/2e5172e9-6b4f-4cc7-b1a8-cf9876feab7e" />

**Cause:** ExternalHoseThread passes tooth_height into ScrewThread unchecked. A tooth taller than the pitch is geometrically impossible (the teeth would have to overlap axially), so the generated profile can't complete within one pitch and the computed root diameter collapses, producing a self-intersecting mesh.

**Fix:** Tooth height is now constrained to the thread pitch, matching how values equal to the pitch already behave. When pitch is 0 (auto), the constraint resolves the metric pitch the same way ScrewThread does internally, so the two always agree. This mirrors the same constraint applied to internal threads in #39. 

**Testing:** Verified with a full render and print. The photo below shows the same setup as above with this patch applied.
<img width="693" height="423" alt="Screenshot 2026-07-11 202701" src="https://github.com/user-attachments/assets/2a8a5a62-27a7-429c-9d20-fafaf1358335" />

**Note:** The combined/ files are not included since they're regenerated by the auto-combine workflow on merge. Feel free to make any changes you see fit to the code before merging. For transparency sake, I want to note that I used Claude to help me figure this out, since I'm not a programmer. However, I tried my best to test/verify/confirm these changes and reduce any unnecessary alterations before submitting this PR.