### PR TITLE
Clarify thread direction labels in the Customizer dropdown

### DIFF
--- a/vacuum-hose-adapter.scad
+++ b/vacuum-hose-adapter.scad
@@ -49,7 +49,7 @@ End1_Hose_EndCap_GridSize = 0;  //0.1
 //Thickness of the walls in the end cap
 End1_Hose_EndCap_GridWallThickness = 0;  //0.1
 // Enable threads Thread side matches Measurement side. Beta feature does not work with taper.
-End1_Hose_Enable_Threads = "disabled"; //["disabled", "enabled", "reversed"]
+End1_Hose_Enable_Threads = "disabled"; //[disabled: disabled, enabled: enabled (left-hand), reversed: standard (right-hand)]
 // Thread Pitch
 End1_Hose_Threads_Pitch = 0;
 // Thread Tooth Angle
@@ -176,7 +176,7 @@ End2_Hose_EndCap_GridSize = 0;  //0.1
 //Thickness of the walls in the end cap
 End2_Hose_EndCap_GridWallThickness = 0;  //0.1
 // Enable threads Thread side matches Measurement side. Beta feature does not work with taper.
-End2_Hose_Enable_Threads = "disabled"; //["disabled", "enabled", "reversed"]
+End2_Hose_Enable_Threads = "disabled"; //[disabled: disabled, enabled: enabled (left-hand), reversed: standard (right-hand)]
 // Thread Pitch
 End2_Hose_Threads_Pitch = 0;
 // Thread Tooth Angle
@@ -274,7 +274,7 @@ End3_Hose_EndCap_GridSize = 0;  //0.1
 //Thickness of the walls in the end cap
 End3_Hose_EndCap_GridWallThickness = 0;  //0.1
 // Enable threads Thread side matches Measurement side. Beta feature does not work with taper.
-End3_Hose_Enable_Threads = "disabled"; //["disabled", "enabled", "reversed"]
+End3_Hose_Enable_Threads = "disabled"; //[disabled: disabled, enabled: enabled (left-hand), reversed: standard (right-hand)]
 // Thread Pitch
 End3_Hose_Threads_Pitch = 0;
 // Thread Tooth Angle


### PR DESCRIPTION
**Problem:** The Customizer dropdown for hose threads offers "disabled", "enabled", and "reversed" — but the names don't match what gets generated: "enabled" actually cuts a left-hand thread, and "reversed" cuts a standard right-hand thread. Users enabling threads for a normal right-hand application will pick "enabled" and get the opposite of what they expect.

<img width="471" height="177" alt="image" src="https://github.com/user-attachments/assets/4a81ea8c-5cbf-4e29-9d3a-97553658ba13" />

**Cause:** In InternalHoseThread/ExternalHoseThread, the thread helix from the library is natively right-hand, but the non-reversed path applies a mirror() (mirror(reverse_thread ? [0,0,0] : [1,0,0])), flipping "enabled" output to left-hand. The "reversed" option skips the mirror and produces the native right-hand thread.

**Fix:** This PR only changes the display labels, using the Customizer's value: label syntax already used elsewhere in the project. The dropdown now shows "disabled", "enabled (left-hand)", and "standard (right-hand)" while the stored values (disabled/enabled/reversed) are unchanged — so existing presets and the thread-generation logic are unaffected.

<img width="230" height="100" alt="Screenshot 2026-07-11 202753" src="https://github.com/user-attachments/assets/29d7b6b0-e8a3-42a5-9be5-5c82c36e6f9a" />

I considered swapping the actual behavior instead, so that "enabled" cuts the right-hand thread users would expect by default — but decided against it, since that would silently reverse the thread direction in every existing preset and previously shared configuration. Relabeling documents the real behavior without changing anyone's output. Happy to rework it the other way if you'd prefer the behavior change.

**Testing:** Opened in the Customizer and confirmed the dropdown displays the new labels and stores the same values as before. No geometry is affected by this change.
<img width="1378" height="916" alt="image" src="https://github.com/user-attachments/assets/82353371-d0b4-48f1-b9ca-7a40c1ada07e" />
<img width="1354" height="895" alt="image" src="https://github.com/user-attachments/assets/59e6f9be-ef67-4cd5-bddf-ce6d24f71c00" />


_Note:_ The combined/ files are not included since they're regenerated by the auto-combine workflow on merge. Feel free to make any changes you see fit to the code before merging. For transparency sake, I want to note that I used Claude to help me figure this out, since I'm not a programmer. However, I tried my best to test/verify/confirm these changes and reduce any unnecessary alterations before submitting this PR.