### PR TITLE
feat(connectors): add Kobalt saw dust outlet and Rigid NXT connector modules

### DIFF
--- a/.cursor/rules/vacuum-hose-adapter-library.mdc
+++ b/.cursor/rules/vacuum-hose-adapter-library.mdc
@@ -1,0 +1,64 @@
+---
+description: Integration guide and rules for using the vacuum-hose-adapter-openscad library
+globs: "*.scad"
+alwaysApply: false
+---
+
+# Vacuum Hose Adapter Library Integration Rule
+
+Use this rule whenever designing, modifying, or creating OpenSCAD models for vacuum hose adapters, dust ports, magnetic quick-connects, osVAC fittings, or custom tool nozzles.
+
+## Library Location
+
+- **Core Module**: `modules/vacuum-hose-adapter.scad`
+- Full technical guide and recipes: [`docs/VACUUM_HOSE_ADAPTER_GUIDE.md`](file:///Users/ksteddom/Source/vacuum-hose-adapter-openscad/docs/VACUUM_HOSE_ADAPTER_GUIDE.md)
+
+## Basic Usage Skeleton
+
+```scad
+include <modules/vacuum-hose-adapter.scad>
+
+// --- Parameters ---
+connector1_diameter = 50;  // mm — Hose outer diameter
+connector2_diameter = 35;  // mm — Tool port inner diameter
+wall_thickness = 2.5;       // mm — Main wall thickness
+
+$fa = 3;
+$fs = 0.1;
+
+// --- Geometry ---
+HoseAdapter(
+  connector1 = UserConnectorSettings(
+    connector = 1,
+    style = "hose",
+    wallThickness = wall_thickness,
+    measurement = "outer",
+    diameter = [connector1_diameter, 0],
+    length = [35, 0],
+    taper = 1
+  ),
+  connector2 = UserConnectorSettings(
+    connector = 2,
+    style = "hose",
+    wallThickness = wall_thickness,
+    measurement = "inner",
+    diameter = [connector2_diameter, 0],
+    length = [30, 0],
+    taper = 0.5
+  ),
+  transitionStyle = "bend+taper",
+  transitionLength = 15
+);
+```
+
+## Supported Connector Styles
+
+- `"hose"`: Standard smooth or tapered hose connection
+- `"mag"`: Magnetic flange connector (requires `magnetCount`, `magnetDiameter`, `magnetThickness`)
+- `"flange"`: Screw mounting flange (requires `flangeWidth`, `flangeThickness`, `screwCount`, `screwDiameter`)
+- `"osvacm"`, `"osvacm32"`, `"osvacf"`, `"osvacf32"`: osVAC standard male/female quick-connect
+- `"centec_male"`, `"centec_female"`: Cen-Tec quick disconnect system
+- `"makita_male"`: Makita tool vacuum port
+- `"dyson"`: Dyson cordless vacuum tool fitting
+- `"camlock"`: Camlock fitting
+- `"nozzle"`: Custom nozzle attachment (`"round"`, `"rectangle"`, `"oval"`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,229 @@
+# Agent Guide: Vacuum Hose Adapter OpenSCAD Repository
+
+Welcome to the `vacuum-hose-adapter-openscad` repository. This repository provides a highly parametric OpenSCAD library for designing and 3D printing custom adapters, magnetic quick-connects, tool dust collection ports, osVAC connectors, and vacuum nozzles.
+
+---
+
+## 1. Repository Structure & Key Entry Points
+
+```
+vacuum-hose-adapter-openscad/
+├── vacuum-hose-adapter.scad        ← Full Customizer entry file (all styles & parameters)
+├── vacuum-hose-adapter-basic.scad  ← Basic Customizer entry file (hose-to-hose simplified)
+├── funnels.scad                    ← Specialized funnel adapter entry point
+├── funnels.json                    ← Funnel parameters & presets
+├── modules/                        ← Core library modules & connector definitions
+│   ├── vacuum-hose-adapter.scad    ← Primary library include file (HoseAdapter, UserConnectorSettings)
+│   ├── constants.scad              ← Constants & indices for connector arrays
+│   ├── modules_pipe.scad           ← Pipe & sweep geometry logic
+│   └── connectors/                 ← Individual connector implementations
+│       ├── connector_object.scad   ← UserConnectorSettings array builder & indices
+│       ├── connector_hose.scad     ← Hose connector module
+│       ├── connector_magnetic.scad ← Magnetic flange connector module
+│       ├── connector_flange.scad   ← Mounting flange connector module
+│       ├── connector_nozzle.scad   ← Nozzle shapes & tips module
+│       ├── connector_osvac.scad    ← osVAC male & female connector modules
+│       ├── connector_centec.scad   ← Cen-Tec male & female quick disconnects
+│       ├── connector_makita.scad   ← Makita tool connector module
+│       ├── connector_dyson.scad    ← Dyson tool connector module
+│       ├── connector_camlock.scad  ← Camlock fitting module
+│       └── connector_dw735.scad    ← DeWalt DW735 planer shroud connector module
+├── demos/                          ← Demonstrations & example scad files
+├── samples/                        ← PNG renders & reference images of sample outputs
+└── scripts/                        ← Automation & render scripts (PowerShell test-render, thumbnail generation)
+```
+
+---
+
+## 2. Library Inclusion & Integration
+
+External OpenSCAD projects (e.g. projects in sibling workspace folders) include the main library file:
+
+```scad
+include <path/to/vacuum-hose-adapter-openscad/modules/vacuum-hose-adapter.scad>
+```
+
+Always use `include` (not `use`) so all functions, defaults, constants, and helper modules are available.
+
+---
+
+## 3. Core API: `HoseAdapter()` & `UserConnectorSettings()`
+
+### 3.1 `HoseAdapter()` Signature
+
+```scad
+HoseAdapter(
+  connector1 = UserConnectorSettings(...),
+  connector2 = UserConnectorSettings(...),
+  transitionStyle = "bend+taper", // "flat", "taper+bend", "bend+taper", "organicbend", "hull", "none"
+  transitionLength = 0,            // Length of transition section (mm)
+  transitionBendRadius = 0,        // Radius of bend if angled (mm)
+  transitionAngle = 0,             // Angle of transition bend (degrees)
+  transitionOffset = [0, 0],       // Center offset [x, y] in mm
+  
+  // Debug & Inspection
+  sliceDebug = false,              // Render cross-section cutaway in preview
+  showCaliper = false,             // Render caliper dimensions in preview
+  end1Color = ["", 1],             // Color specification [color_name, alpha]
+  end2Color = ["", 1],
+  transitionColor = ["", 1]
+);
+```
+
+---
+
+### 3.2 `UserConnectorSettings()` Parameter Reference
+
+#### General Parameters
+| Parameter | Default | Description |
+|---|---|---|
+| `connector` | `1` | `1` for End 1, `2` for End 2. |
+| `style` | `"hose"` | Connector type string (see Section 3.3). |
+| `wallThickness` | `2` | Main wall thickness in mm. |
+| `measurement` | `"outer"` | `"outer"` (OD measurement for insertion into hose) or `"inner"` (ID measurement for slipping over tool port). |
+| `diameter` | `[100, 0]` | Vector `[mm, inch]` for connector diameter. |
+| `length` | `[40, 0]` | Vector `[mm, inch]` for connector length. |
+| `taper` | `0` | Taper amount in mm. Positive tapers outward toward end. |
+| `rotation` | `0` | Z-axis rotation angle in degrees. |
+
+#### Hose Connector Parameters (`style = "hose"`)
+| Parameter | Description |
+|---|---|
+| `stopThickness` | Thickness of hose stop ring (mm). `0` disables stop. |
+| `stopLength` | Length of hose stop ring (mm). |
+| `stopSymmetrical` | `true`/`false` - taper both sides of stop. |
+| `barbsCount` | Number of retention barbs. |
+| `barbsThickness` | Barb height/thickness (mm). |
+| `barbsSymmetrical` | `true`/`false` - taper both sides of barbs. |
+| `endCapThickness` | End cap thickness (mm). `0` disables. |
+| `endCapGridSize` | Mesh grid hole size for debris guard (mm). |
+| `enableThreads` | `"disabled"`, `"enabled"` (left-hand), or `"reversed"` (right-hand). |
+| `threadPitch` | Thread pitch in mm. |
+
+#### Magnetic Flange Parameters (`style = "mag"`)
+| Parameter | Description |
+|---|---|
+| `magnetCount` | Number of magnets (e.g. `8`). |
+| `magnetDiameter` | Magnet pocket diameter (mm). Add 0.3–0.5mm clearance (e.g. `10.5` for 10mm magnet). |
+| `magnetThickness` | Magnet depth (mm). Add 0.3–0.5mm clearance (e.g. `2.5` for 2mm magnet). |
+| `magnetBorder` | Material around magnet pockets (mm). Default `2`. |
+| `flangeThickness` | Total magnetic flange thickness (mm). Default `6`. |
+| `alignmentRing` | `"no"`, `"recessed"`, or `"protruding"` seal ring interface. |
+
+#### Screw Flange Parameters (`style = "flange"`)
+| Parameter | Description |
+|---|---|
+| `flangeWidth` | Extra flange width added to connector diameter (mm). |
+| `flangeThickness` | Mounting flange plate thickness (mm). |
+| `screwCount` | Number of mounting holes (e.g. `4`). |
+| `screwDiameter` | Screw hole diameter (mm). |
+
+#### Nozzle Parameters (`style = "nozzle"`)
+| Parameter | Description |
+|---|---|
+| `nozzleShape` | `"round"`, `"rectangle"`, or `"oval"`. |
+| `nozzleSize` | `[width, depth, height]` vector for tip opening. |
+| `nozzleRadius` | Corner rounding radius for nozzle opening (mm). |
+| `nozzleChamferAngle` | Bevel angle at tip end (degrees). |
+
+---
+
+### 3.3 Connector Styles Summary
+
+| `style` Identifier | Description |
+|---|---|
+| `"hose"` | Standard smooth, tapered, barbed, or threaded hose connector |
+| `"mag"` | Quick-disconnect magnetic flange with magnet pockets |
+| `"flange"` | Screw mounting flange for tool body attachment |
+| `"osvacm"`, `"osvacm32"` | osVAC male quick-connect coupler |
+| `"osvacf"`, `"osvacf32"` | osVAC female quick-connect coupler |
+| `"centec_male"`, `"centec_female"` | Cen-Tec quick disconnect system |
+| `"makita_male"` | Makita shop tool vacuum port connector |
+| `"dyson"` | Dyson cordless tool latching attachment |
+| `"camlock"` | Camlock quick disconnect fitting |
+| `"dw735"` | DeWalt DW735 planer dust port adapter |
+| `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
+| `"none"` | Open or flat end |
+
+---
+
+## 4. Code Examples for Agents
+
+### Example 1: 50mm Hose to 35mm Tool Port Adapter
+
+```scad
+include <modules/vacuum-hose-adapter.scad>
+
+$fa = 3;
+$fs = 0.1;
+
+HoseAdapter(
+  connector1 = UserConnectorSettings(
+    connector = 1,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [50, 0],
+    length = [35, 0],
+    taper = 1,
+    stopThickness = 1.5,
+    stopLength = 3,
+    stopSymmetrical = true
+  ),
+  connector2 = UserConnectorSettings(
+    connector = 2,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "inner",
+    diameter = [35, 0],
+    length = [30, 0],
+    taper = 0.5
+  ),
+  transitionStyle = "bend+taper",
+  transitionLength = 15
+);
+```
+
+### Example 2: Magnetic Flange Coupler
+
+```scad
+include <modules/vacuum-hose-adapter.scad>
+
+$fa = 3;
+$fs = 0.1;
+
+HoseAdapter(
+  connector1 = UserConnectorSettings(
+    connector = 1,
+    style = "mag",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [50, 0],
+    length = [20, 0],
+    magnetCount = 8,
+    magnetDiameter = 10.5,
+    magnetThickness = 2.5,
+    magnetBorder = 3,
+    flangeThickness = 6,
+    alignmentRing = "recessed"
+  ),
+  connector2 = UserConnectorSettings(
+    connector = 2,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [40, 0],
+    length = [35, 0],
+    taper = 1
+  ),
+  transitionStyle = "bend+taper",
+  transitionLength = 15
+);
+```
+
+---
+
+## 5. Guide Pointers
+
+- Detailed guide & recipes: [`docs/VACUUM_HOSE_ADAPTER_GUIDE.md`](file:///Users/ksteddom/Source/vacuum-hose-adapter-openscad/docs/VACUUM_HOSE_ADAPTER_GUIDE.md)
+- Cursor agent rule: [`.cursor/rules/vacuum-hose-adapter-library.mdc`](file:///Users/ksteddom/Source/vacuum-hose-adapter-openscad/.cursor/rules/vacuum-hose-adapter-library.mdc)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ HoseAdapter(
 | `"dyson"` | Dyson cordless tool latching attachment |
 | `"camlock"` | Camlock quick disconnect fitting |
 | `"dw735"` | DeWalt DW735 planer dust port adapter |
+| `"kobalt"` | Kobalt saw dust outlet female socket with recessed ring channels |
 | `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
 | `"none"` | Open or flat end |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ HoseAdapter(
 | `"camlock"` | Camlock quick disconnect fitting |
 | `"dw735"` | DeWalt DW735 planer dust port adapter |
 | `"kobalt"` | Kobalt saw dust outlet female socket with recessed ring channels |
+| `"rigid_nxt"` | Rigid NXT shop vac hose connector with locking ridges |
 | `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
 | `"none"` | Open or flat end |
 

--- a/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
+++ b/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
@@ -104,6 +104,7 @@ HoseAdapter(
 | `"dyson"` | Dyson cordless tool latching attachment |
 | `"camlock"` | Camlock quick disconnect fitting |
 | `"dw735"` | DeWalt DW735 planer dust port adapter |
+| `"kobalt"` | Kobalt saw dust outlet female socket with recessed ring channels |
 | `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
 | `"none"` | Open or flat end |
 

--- a/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
+++ b/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
@@ -105,6 +105,7 @@ HoseAdapter(
 | `"camlock"` | Camlock quick disconnect fitting |
 | `"dw735"` | DeWalt DW735 planer dust port adapter |
 | `"kobalt"` | Kobalt saw dust outlet female socket with recessed ring channels |
+| `"rigid_nxt"` | Rigid NXT shop vac hose connector with locking ridges |
 | `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
 | `"none"` | Open or flat end |
 

--- a/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
+++ b/docs/VACUUM_HOSE_ADAPTER_GUIDE.md
@@ -1,0 +1,182 @@
+# Agent & Developer Guide: Vacuum Hose Adapter OpenSCAD Library
+
+This guide provides technical documentation for AI agents and human developers for utilizing, embedding, or extending the `vacuum-hose-adapter-openscad` library.
+
+---
+
+## 1. Including the Library
+
+In your OpenSCAD scripts, include the primary library module:
+
+```scad
+include <modules/vacuum-hose-adapter.scad>
+```
+
+If including from an external repository (e.g. `openSCAD/my_project/my_project.scad`), use relative pathing:
+
+```scad
+include <../../vacuum-hose-adapter-openscad/modules/vacuum-hose-adapter.scad>
+```
+
+---
+
+## 2. Core API Architecture
+
+The entry function for constructing dual-connector adapters is `HoseAdapter()`. It consumes two connector object structures constructed via `UserConnectorSettings()`.
+
+```scad
+HoseAdapter(
+  connector1 = UserConnectorSettings(...),
+  connector2 = UserConnectorSettings(...),
+  transitionStyle = "bend+taper", // "flat", "taper+bend", "bend+taper", "organicbend", "hull", "none"
+  transitionLength = 0,            // Length of transition section in mm
+  transitionBendRadius = 0,        // Bend radius in mm
+  transitionAngle = 0,             // Angle of transition bend in degrees
+  transitionOffset = [0, 0],       // [X, Y] offset in mm
+  
+  sliceDebug = false,              // Cutaway view for debugging interior
+  showCaliper = false,             // Render dimension calipers
+  end1Color = ["", 1],
+  end2Color = ["", 1],
+  transitionColor = ["", 1]
+);
+```
+
+---
+
+## 3. Parameter Dictionary (`UserConnectorSettings`)
+
+### Common Options
+- `connector`: `1` or `2`.
+- `style`: Connector type (see Section 4).
+- `wallThickness`: Main wall thickness in mm (default `2`).
+- `measurement`: `"outer"` (OD for inserting into hose/port) or `"inner"` (ID for fitting over pipe).
+- `diameter`: `[mm, inch]` tuple, e.g., `[50, 0]`.
+- `length`: `[mm, inch]` tuple, e.g., `[40, 0]`.
+- `taper`: Taper angle in mm. Positive tapers outward toward end.
+- `rotation`: Rotation angle around Z-axis in degrees.
+
+### Hose Connector Options (`style = "hose"`)
+- `stopThickness`: Thickness of hose stop ring (mm). `0` disables stop.
+- `stopLength`: Length of hose stop ring (mm).
+- `stopSymmetrical`: `true`/`false` - taper both sides of stop.
+- `barbsCount`: Number of retention barbs.
+- `barbsThickness`: Height/thickness of barbs (mm).
+- `barbsSymmetrical`: `true`/`false`.
+- `endCapThickness`: Debris cap thickness (mm). `0` disables cap.
+- `endCapGridSize`: Grid hole size for debris cap (mm).
+- `enableThreads`: `"disabled"`, `"enabled"` (left-hand thread), or `"reversed"` (right-hand thread).
+- `threadPitch`: Pitch in mm.
+
+### Magnetic Flange Options (`style = "mag"`)
+- `magnetCount`: Number of magnet pockets.
+- `magnetDiameter`: Hole diameter in mm (add 0.3–0.5mm clearance, e.g., `10.5` for 10mm magnet).
+- `magnetThickness`: Pocket depth in mm (add 0.3–0.5mm clearance, e.g., `2.5` for 2mm magnet).
+- `magnetBorder`: Extra wall material around magnet pockets (mm).
+- `flangeThickness`: Total flange face thickness (mm).
+- `alignmentRing`: `"no"`, `"recessed"`, or `"protruding"`.
+
+### Screw Flange Options (`style = "flange"`)
+- `flangeWidth`: Added flange width relative to connector diameter (mm).
+- `flangeThickness`: Flange plate thickness (mm).
+- `screwCount`: Number of screw holes.
+- `screwDiameter`: Hole diameter in mm (e.g. `4.5` for M4).
+
+### Nozzle Options (`style = "nozzle"`)
+- `nozzleShape`: `"round"`, `"rectangle"`, or `"oval"`.
+- `nozzleSize`: `[width, depth, height]` vector for tip opening.
+- `nozzleRadius`: Corner rounding radius (mm).
+- `nozzleChamferAngle`: Bevel angle at tip end (degrees).
+
+---
+
+## 4. Supported Connector Styles
+
+| Style Code | Description |
+|---|---|
+| `"hose"` | Standard smooth, tapered, barbed, or threaded hose connector |
+| `"mag"` | Quick-disconnect magnetic flange with magnet pockets |
+| `"flange"` | Mounting flange with screw holes for tool bodies |
+| `"osvacm"`, `"osvacm32"` | osVAC male quick-connect coupler |
+| `"osvacf"`, `"osvacf32"` | osVAC female quick-connect coupler |
+| `"centec_male"`, `"centec_female"` | Cen-Tec quick disconnect system |
+| `"makita_male"` | Makita tool vacuum port connector |
+| `"dyson"` | Dyson cordless tool latching attachment |
+| `"camlock"` | Camlock quick disconnect fitting |
+| `"dw735"` | DeWalt DW735 planer dust port adapter |
+| `"nozzle"` | Crevice tool, wide nozzle, or utility vacuum nozzle |
+| `"none"` | Open or flat end |
+
+---
+
+## 5. Standard Code Recipes
+
+### Recipe 1: 50mm to 35mm Hose Adapter
+```scad
+include <modules/vacuum-hose-adapter.scad>
+
+$fa = 3;
+$fs = 0.1;
+
+HoseAdapter(
+  connector1 = UserConnectorSettings(
+    connector = 1,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [50, 0],
+    length = [35, 0],
+    taper = 1,
+    stopThickness = 1.5,
+    stopLength = 3,
+    stopSymmetrical = true
+  ),
+  connector2 = UserConnectorSettings(
+    connector = 2,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "inner",
+    diameter = [35, 0],
+    length = [30, 0],
+    taper = 0.5
+  ),
+  transitionStyle = "bend+taper",
+  transitionLength = 15
+);
+```
+
+### Recipe 2: Magnetic Flange to Hose
+```scad
+include <modules/vacuum-hose-adapter.scad>
+
+$fa = 3;
+$fs = 0.1;
+
+HoseAdapter(
+  connector1 = UserConnectorSettings(
+    connector = 1,
+    style = "mag",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [50, 0],
+    length = [20, 0],
+    magnetCount = 8,
+    magnetDiameter = 10.5,
+    magnetThickness = 2.5,
+    magnetBorder = 3,
+    flangeThickness = 6,
+    alignmentRing = "recessed"
+  ),
+  connector2 = UserConnectorSettings(
+    connector = 2,
+    style = "hose",
+    wallThickness = 2.5,
+    measurement = "outer",
+    diameter = [40, 0],
+    length = [35, 0],
+    taper = 1
+  ),
+  transitionStyle = "bend+taper",
+  transitionLength = 15
+);
+```

--- a/modules/connectors/connector_hose.scad
+++ b/modules/connectors/connector_hose.scad
@@ -82,6 +82,8 @@ module HoseConnector(
     threadPitch=0,
     threadToothAngle=30,
     threadToothHeight=0,
+    threadToothWidth=0,
+    threadProfile="v_angle",
     help
 )
 {
@@ -118,12 +120,17 @@ module HoseConnector(
     str("chamferWidth must be a number greater than or equal to 0; got: ", chamferWidth));
   assert(is_string(enableThreads) && (enableThreads == "disabled" || enableThreads == "enabled" || enableThreads == "reversed"),
     str("enableThreads must be 'disabled', 'enabled', or 'reversed'; got: ", enableThreads));
+  assert(is_string(threadProfile) && (threadProfile == "v_angle" || threadProfile == "round"),
+    str("threadProfile must be 'v_angle' or 'round'; got: ", threadProfile));
+
   assert(is_num(threadPitch) && threadPitch >= 0,
     str("threadPitch must be a number greater than or equal to 0; got: ", threadPitch));
   assert(is_num(threadToothAngle) && threadToothAngle >= 0 && threadToothAngle <= 90,
     str("threadToothAngle must be between 0 and 90; got: ", threadToothAngle));
   assert(is_num(threadToothHeight) && threadToothHeight >= 0,
     str("threadToothHeight must be a number greater than or equal to 0; got: ", threadToothHeight));
+  assert(is_num(threadToothWidth) && threadToothWidth >= 0,
+    str("threadToothWidth must be a number greater than or equal to 0; got: ", threadToothWidth));
 
   assert(stopLength == 0 || stopWidth > 0,
     str("stopWidth must be greater than 0 when stopLength is enabled; stopLength=", stopLength, ", stopWidth=", stopWidth));
@@ -150,16 +157,33 @@ module HoseConnector(
 
         //Inner cylinder or internal thread to remove
         if (enableThreads != "disabled" && connectorMeasurement == "inner") {
-          translate([0, 0, -fudgeFactor])
-          mirror((enableThreads == "reversed") ? [1,0,0] : [0,0,0])
-          ScrewThread(
-            outer_diam = innerStartDiameter,
-            height = length + fudgeFactor*2,
-            pitch = threadPitch,
-            tooth_angle = threadToothAngle,
-            tooth_height = threadToothHeight,
-            referenceThreadOuter = true
-          );
+          if (threadProfile == "round") {
+            RoundScrewThread(
+              major_diam = innerStartDiameter,
+              height = length,
+              pitch = threadPitch,
+              tooth_height = threadToothHeight,
+              tooth_width = threadToothWidth,
+              reverse = (enableThreads == "reversed")
+            );
+            // Clean open center bore at innerStartDiameter for half-circle grooves
+            translate([0, 0, -fudgeFactor])
+            cylinder(h = length + fudgeFactor*4, d = innerStartDiameter);
+          } else {
+            translate([0, 0, -threadPitch])
+            mirror((enableThreads == "reversed") ? [1,0,0] : [0,0,0])
+            ScrewThread(
+              outer_diam = innerStartDiameter,
+              height = length + threadPitch*2,
+              pitch = threadPitch,
+              tooth_angle = threadToothAngle,
+              tooth_height = threadToothHeight,
+              referenceThreadOuter = true
+            );
+            // Clean open center bore
+            translate([0, 0, -fudgeFactor])
+            cylinder(h = length + fudgeFactor*4, d = innerStartDiameter - 2*threadToothHeight);
+          }
         } else {
           translate([0,0,0-fudgeFactor])
           hull()

--- a/modules/connectors/connector_hose.scad
+++ b/modules/connectors/connector_hose.scad
@@ -148,13 +148,26 @@ module HoseConnector(
             cylinder(fudgeFactor, d=innerEndDiameter+2*wallThickness);
         }
 
-        //Inner cylinder to remove
-        translate([0,0,0-fudgeFactor])
-        hull()
-        {
-          cylinder(fudgeFactor, d=innerStartDiameter);
-          translate([0,0,length+2*fudgeFactor])
-            cylinder(fudgeFactor, d=innerEndDiameter);
+        //Inner cylinder or internal thread to remove
+        if (enableThreads != "disabled" && connectorMeasurement == "inner") {
+          translate([0, 0, -fudgeFactor])
+          mirror((enableThreads == "reversed") ? [1,0,0] : [0,0,0])
+          ScrewThread(
+            outer_diam = innerStartDiameter,
+            height = length + fudgeFactor*2,
+            pitch = threadPitch,
+            tooth_angle = threadToothAngle,
+            tooth_height = threadToothHeight,
+            referenceThreadOuter = true
+          );
+        } else {
+          translate([0,0,0-fudgeFactor])
+          hull()
+          {
+            cylinder(fudgeFactor, d=innerStartDiameter);
+            translate([0,0,length+2*fudgeFactor])
+              cylinder(fudgeFactor, d=innerEndDiameter);
+          }
         }
         if(chamferLength >0)
         {
@@ -172,26 +185,15 @@ module HoseConnector(
         }
       }
 
-      if(enableThreads != "disabled"){
-        if(connectorMeasurement == "outer"){
-          ExternalHoseThread(
-            diameter = innerStartDiameter+wallThickness,
-            wallThickness=wallThickness,
-            height=length,
-            pitch=threadPitch,
-            tooth_angle=threadToothAngle,
-            tooth_height=threadToothHeight,
-            reverse_thread=(enableThreads == "reversed"));
-        } else {
-        InternalHoseThread(
-          diameter = innerStartDiameter,
+      if(enableThreads != "disabled" && connectorMeasurement == "outer"){
+        ExternalHoseThread(
+          diameter = innerStartDiameter+wallThickness,
           wallThickness=wallThickness,
           height=length,
           pitch=threadPitch,
           tooth_angle=threadToothAngle,
           tooth_height=threadToothHeight,
           reverse_thread=(enableThreads == "reversed"));
-        }
       }
     }
 

--- a/modules/connectors/connector_kobalt.scad
+++ b/modules/connectors/connector_kobalt.scad
@@ -1,0 +1,99 @@
+include <../constants.scad>
+include <connector_hose.scad>
+
+kobaltVersion = "1.0";
+kobaltMinLength = 16.7;
+kobaltMeasurement = "inner";
+kobaltBaseOD = 38.20;
+kobaltRingOD = 39.85;
+kobaltFitClearance = -0.30;
+kobaltInnerDiameter = kobaltBaseOD + kobaltFitClearance; // 37.90mm
+kobaltWallThickness = 2.50;
+
+kobaltSettings = ["kobalt", [
+  [iSettingsLength, kobaltMinLength],
+  [iSettingsMeasurement, kobaltMeasurement],
+  [iSettingsDiameter, kobaltInnerDiameter],
+  [iSettingsTaper, 0],
+  [iSettingsWallThickness, kobaltWallThickness],
+  [iSettingsVersion, kobaltVersion]
+]];
+
+kobaltConnector_demo = false;
+if (kobaltConnector_demo) {
+  $fn = 128;
+  KobaltConnector(help = true);
+}
+
+module KobaltConnector(
+  innerEndDiameter = kobaltInnerDiameter,
+  length = kobaltMinLength,
+  wallThickness = kobaltWallThickness,
+  fitClearance = kobaltFitClearance,
+  ringOD = kobaltRingOD,
+  entryChamfer = 1.50,
+  enableRecesses = true,
+  help = false,
+  $fn = 64
+) {
+  assert(is_num(innerEndDiameter) && innerEndDiameter > 0, "innerEndDiameter must be a number > 0");
+  assert(is_num(length) && length > 0, "length must be a number > 0");
+  assert(is_num(wallThickness) && wallThickness > 0, "wallThickness must be a number > 0");
+
+  recess_id = ringOD + fitClearance;
+  recess_r_outer = recess_id / 2;
+  recess_r_inner = innerEndDiameter / 2 - 0.1;
+  depth = recess_r_outer - recess_r_inner;
+
+  upper_h = (8.35 - 5.50) / 2;
+  upper_points = [
+    [recess_r_inner, upper_h],
+    for (a = [90 : -10 : -90])
+      [recess_r_inner + depth * cos(a), upper_h * sin(a)],
+    [recess_r_inner, -upper_h]
+  ];
+
+  lower_h = (16.70 - 14.00) / 2;
+  lower_points = [
+    [recess_r_inner, lower_h],
+    for (a = [90 : -10 : -90])
+      [recess_r_inner + depth * cos(a), lower_h * sin(a)],
+    [recess_r_inner, -lower_h]
+  ];
+
+  difference() {
+    HoseConnector(
+      connectorMeasurement = "inner",
+      innerStartDiameter = innerEndDiameter,
+      innerEndDiameter = innerEndDiameter,
+      length = length,
+      wallThickness = wallThickness,
+      help = help,
+      $fn = $fn
+    );
+
+    if (enableRecesses && depth > 0) {
+      // Upper ring recess (depth 5.50mm to 8.35mm from lip, peak at 6.925mm)
+      translate([0, 0, length - 6.925])
+        rotate_extrude($fn = $fn)
+          polygon(points = upper_points);
+
+      // Lower ring recess (depth 14.00mm to 16.70mm from lip, peak at 15.35mm)
+      translate([0, 0, length - 15.35])
+        rotate_extrude($fn = $fn)
+          polygon(points = lower_points);
+    }
+
+    if (entryChamfer > 0) {
+      translate([0, 0, length - entryChamfer]) {
+        rotate_extrude($fn = $fn) {
+          polygon(points = [
+            [innerEndDiameter / 2, -0.1],
+            [innerEndDiameter / 2 + entryChamfer + 0.1, entryChamfer + 0.1],
+            [innerEndDiameter / 2, entryChamfer + 0.1]
+          ]);
+        }
+      }
+    }
+  }
+}

--- a/modules/connectors/connector_object.scad
+++ b/modules/connectors/connector_object.scad
@@ -17,7 +17,8 @@ iEnableThreads=iBarbsSymmetrical+1;
 iThreadPitch=iEnableThreads+1;
 iThreadToothAngle=iThreadPitch+1;
 iThreadToothHeight=iThreadToothAngle+1;
-iMagnetCount=iThreadToothHeight+1;
+iThreadProfile=iThreadToothHeight+1;
+iMagnetCount=iThreadProfile+1;
 iMagnetDiameter=iMagnetCount+1;
 iMagnetThickness=iMagnetDiameter+1;
 iMagnetBorder=iMagnetThickness+1;
@@ -192,6 +193,7 @@ function UserConnectorSettings(
   threadPitch = 0,
   threadToothAngle = 30,
   threadToothHeight = 0,
+  threadProfile = "v_angle",
   magnetCount = 0,
   magnetDiameter = 0,
   magnetThickness = 0,
@@ -249,6 +251,7 @@ function UserConnectorSettings(
     threadPitch,
     threadToothAngle,
     threadToothHeight,
+    threadProfile,
     magnetCount,
     magnetDiameter,
     magnetThickness,
@@ -471,6 +474,7 @@ function getConnectorSettings(
         userSettings[iThreadPitch],
         userSettings[iThreadToothAngle],
         userSettings[iThreadToothHeight],
+        userSettings[iThreadProfile],
         userSettings[iMagnetCount],
         userSettings[iMagnetDiameter],
         userSettings[iMagnetThickness],

--- a/modules/connectors/connector_rigid_nxt.scad
+++ b/modules/connectors/connector_rigid_nxt.scad
@@ -1,0 +1,86 @@
+include <../constants.scad>
+include <connector_hose.scad>
+
+nxtVersion = "1.0";
+nxtMinLength = 25.0;
+nxtMeasurement = "outer";
+nxtOuterDiameter = 63.70;
+nxtInnerDiameter = 58.20;
+nxtWallThickness = (nxtOuterDiameter - nxtInnerDiameter) / 2; // 2.75mm
+nxtRidgeHeight = 2.60;
+nxtRidgeCount = 6;
+nxtRidgeSpan = 19.25;
+nxtRidgeArc = 55;
+nxtRidgeOffset = 2.0;
+
+rigidNxtSettings = ["rigid_nxt", [
+  [iSettingsLength, nxtMinLength],
+  [iSettingsMeasurement, nxtMeasurement],
+  [iSettingsDiameter, nxtOuterDiameter],
+  [iSettingsTaper, 0],
+  [iSettingsWallThickness, nxtWallThickness],
+  [iSettingsVersion, nxtVersion]
+]];
+
+rigidNxtConnector_demo = false;
+if (rigidNxtConnector_demo) {
+  $fn = 128;
+  RigidNXTConnector(help = true);
+}
+
+module RigidNXTConnector(
+  outerStartDiameter = nxtOuterDiameter,
+  outerEndDiameter = nxtOuterDiameter,
+  length = nxtMinLength,
+  wallThickness = nxtWallThickness,
+  ridgeCount = nxtRidgeCount,
+  ridgeHeight = nxtRidgeHeight,
+  ridgeSpan = nxtRidgeSpan,
+  ridgeArc = nxtRidgeArc,
+  ridgeOffset = nxtRidgeOffset,
+  help = false,
+  $fn = 64
+) {
+  assert(is_num(outerStartDiameter) && outerStartDiameter > 0, "outerStartDiameter must be a number > 0");
+  assert(is_num(length) && length > 0, "length must be a number > 0");
+  assert(is_num(wallThickness) && wallThickness > 0, "wallThickness must be a number > 0");
+
+  innerStartDiameter = outerStartDiameter - wallThickness * 2;
+  innerEndDiameter = outerEndDiameter - wallThickness * 2;
+  ridgePitch = ridgeCount > 1 ? ridgeSpan / (ridgeCount - 1) : 0;
+  r_base = outerStartDiameter / 2;
+  r_max = r_base + ridgeHeight;
+  ramp_len = ridgePitch * 0.82;
+
+  union() {
+    HoseConnector(
+      connectorMeasurement = "outer",
+      innerStartDiameter = innerStartDiameter,
+      innerEndDiameter = innerEndDiameter,
+      length = length,
+      wallThickness = wallThickness,
+      help = help,
+      $fn = $fn
+    );
+
+    if (ridgeCount > 0 && ridgeHeight > 0) {
+      rotate([0, 0, 90 - ridgeArc / 2]) {
+        rotate_extrude(angle = ridgeArc, $fn = $fn) {
+          for (i = [0 : ridgeCount - 1]) {
+            z0 = ridgeOffset + i * ridgePitch;
+            z1 = z0 + ramp_len;
+            z2 = z0 + ridgePitch;
+
+            if (z2 <= length + 0.1) {
+              polygon(points = [
+                [r_base - 0.1, z0],
+                [r_max, z1],
+                [r_base - 0.1, z2]
+              ]);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/connectors/connectors.scad
+++ b/modules/connectors/connectors.scad
@@ -17,6 +17,7 @@ include <connector_festool.scad>
 include <connector_makita.scad>
 include <connector_osvac.scad>
 include <connector_kobalt.scad>
+include <connector_rigid_nxt.scad>
 
 // order matters needs to come after the connectors
 include <connector_common_post.scad>

--- a/modules/connectors/connectors.scad
+++ b/modules/connectors/connectors.scad
@@ -16,6 +16,7 @@ include <connector_dw735.scad>
 include <connector_festool.scad>
 include <connector_makita.scad>
 include <connector_osvac.scad>
+include <connector_kobalt.scad>
 
 // order matters needs to come after the connectors
 include <connector_common_post.scad>

--- a/modules/modules_threads.scad
+++ b/modules/modules_threads.scad
@@ -80,7 +80,6 @@ module InternalHoseThread(
         }
     }
   }
-  }
 }
 
 // create an external thread outside a hose (like a bolt)

--- a/modules/modules_threads.scad
+++ b/modules/modules_threads.scad
@@ -40,7 +40,6 @@ module InternalHoseThread(
   tooth_angle=30,
   tooth_height=0,
   reverse_thread = false) {
-
   // Same bore sizing as ScrewHole.
   cut_diam = 1.01*diameter + 1.25*tolerance;
   _pitch = (pitch==0) ? ThreadPitch(cut_diam) : pitch;
@@ -53,18 +52,34 @@ module InternalHoseThread(
   shift = (_pitch - _tooth_height) / (2*tan(tooth_angle));
   extra_height = 0.001 * height;
 
-  mirror(reverse_thread ? [0,0,0] :[1,0,0])
-  difference() {
-    cylinder(h=height, r=diameter/2+wallThickness);
-    translate(position)
-      rotate(rotation)
-      translate([0, 0, -extra_height/2])
-      intersection() {
-        ScrewThread(cut_diam + 2*shift, height + extra_height,
-          pitch=_pitch, tooth_angle=tooth_angle, tolerance=tolerance);
-        // ScrewThread's crest radius for cut_diam, shrinkage correction included.
-        cylinder(h=height + extra_height, r=(cut_diam + 0.25*tolerance)/2);
-      }
+  if (reverse_thread) {
+    mirror([1,0,0])
+    difference() {
+      cylinder(h=height, r=diameter/2+wallThickness);
+      translate(position)
+        rotate(rotation)
+        translate([0, 0, -extra_height/2])
+        intersection() {
+          ScrewThread(cut_diam + 2*shift, height + extra_height,
+            pitch=_pitch, tooth_angle=tooth_angle, tolerance=tolerance);
+          // ScrewThread's crest radius for cut_diam, shrinkage correction included.
+          cylinder(h=height + extra_height, r=(cut_diam + 0.25*tolerance)/2);
+        }
+    }
+  } else {
+    difference() {
+      cylinder(h=height, r=diameter/2+wallThickness);
+      translate(position)
+        rotate(rotation)
+        translate([0, 0, -extra_height/2])
+        intersection() {
+          ScrewThread(cut_diam + 2*shift, height + extra_height,
+            pitch=_pitch, tooth_angle=tooth_angle, tolerance=tolerance);
+          // ScrewThread's crest radius for cut_diam, shrinkage correction included.
+          cylinder(h=height + extra_height, r=(cut_diam + 0.25*tolerance)/2);
+        }
+    }
+  }
   }
 }
 
@@ -84,22 +99,42 @@ module ExternalHoseThread(
 
   fudgeFactor = 0.01;
 
-  mirror(reverse_thread ? [0,0,0] :[1,0,0])
-  translate([0,0,height])
-  rotate([0,180,0])
-    difference(){
-      ScrewThread(
-        outer_diam=diameter+wallThickness*2,
-        height=height,
-        tolerance=tolerance,
-        tip_height=tip_height == 0 ? ThreadPitch(diameter) : tip_height,
-        pitch=pitch,
-        tooth_angle=tooth_angle,
-        tooth_height=min(tooth_height, pitch==0 ? ThreadPitch(diameter+wallThickness*2) : pitch),
-        tip_min_fract=tip_min_fract,
-        referenceThreadOuter= false);
+  if (reverse_thread) {
+    mirror([1,0,0])
+    translate([0,0,height])
+    rotate([0,180,0])
+      difference(){
+        ScrewThread(
+          outer_diam=diameter+wallThickness*2,
+          height=height,
+          tolerance=tolerance,
+          tip_height=tip_height == 0 ? ThreadPitch(diameter) : tip_height,
+          pitch=pitch,
+          tooth_angle=tooth_angle,
+          tooth_height=min(tooth_height, pitch==0 ? ThreadPitch(diameter+wallThickness*2) : pitch),
+          tip_min_fract=tip_min_fract,
+          referenceThreadOuter= false);
 
-    translate([0,0,-fudgeFactor])
-      cylinder(h=height+fudgeFactor*2, d=diameter);
-    }
+      translate([0,0,-fudgeFactor])
+        cylinder(h=height+fudgeFactor*2, d=diameter);
+      }
+  } else {
+    translate([0,0,height])
+    rotate([0,180,0])
+      difference(){
+        ScrewThread(
+          outer_diam=diameter+wallThickness*2,
+          height=height,
+          tolerance=tolerance,
+          tip_height=tip_height == 0 ? ThreadPitch(diameter) : tip_height,
+          pitch=pitch,
+          tooth_angle=tooth_angle,
+          tooth_height=min(tooth_height, pitch==0 ? ThreadPitch(diameter+wallThickness*2) : pitch),
+          tip_min_fract=tip_min_fract,
+          referenceThreadOuter= false);
+
+      translate([0,0,-fudgeFactor])
+        cylinder(h=height+fudgeFactor*2, d=diameter);
+      }
+  }
 }

--- a/modules/modules_threads.scad
+++ b/modules/modules_threads.scad
@@ -137,3 +137,43 @@ module ExternalHoseThread(
       }
   }
 }
+
+// create a round / half-circle (knuckle) internal or external thread cutter
+module RoundScrewThread(
+    major_diam = 33.29,
+    height = 14.0,
+    pitch = 2.7,
+    tooth_height = 0.98,
+    tooth_width = 2.33,
+    reverse = true,
+    steps_per_turn = 48
+) {
+    total_turns = height / pitch + 2;
+    steps = ceil(total_turns * steps_per_turn);
+    d_theta = 360 / steps_per_turn;
+    dz = pitch / steps_per_turn;
+    
+    r_center = (major_diam / 2);
+    rx = tooth_height;
+    ry = (tooth_width > 0) ? tooth_width / 2 : tooth_height;
+    rz = (tooth_width > 0) ? tooth_width / 2 : tooth_height;
+    
+    for (s = [0:steps-1]) {
+        let(
+            t1 = (reverse ? -1 : 1) * s * d_theta,
+            z1 = s * dz - pitch,
+            t2 = (reverse ? -1 : 1) * (s + 1) * d_theta,
+            z2 = (s + 1) * dz - pitch
+        )
+        hull() {
+            translate([r_center * cos(t1), r_center * sin(t1), z1])
+                rotate([0, 0, t1])
+                scale([rx, ry, rz])
+                sphere(r = 1, $fn = 24);
+            translate([r_center * cos(t2), r_center * sin(t2), z2])
+                rotate([0, 0, t2])
+                scale([rx, ry, rz])
+                sphere(r = 1, $fn = 24);
+        }
+    }
+}

--- a/modules/vacuum-hose-adapter.scad
+++ b/modules/vacuum-hose-adapter.scad
@@ -256,6 +256,18 @@ module adapter(
             help = help,
             $fn = $fn);
         }
+        else if(con[iStyle] == "rigid_nxt" || con[iStyle] == "nxt")
+        {
+          translate([0, 0, con[iLength]+con[iStopLength]])
+          mirror ([0,0,1])
+          RigidNXTConnector(
+            outerStartDiameter = con[iOuterStartDiameter],
+            outerEndDiameter = con[iOuterEndDiameter],
+            length = con[iLength],
+            wallThickness = con[iWallThickness],
+            help = help,
+            $fn = $fn);
+        }
         else if(con[iStyle] == "osvacm" || con[iStyle] == "osvacm32")
         {
           translate([0, 0, con[iLength]])

--- a/modules/vacuum-hose-adapter.scad
+++ b/modules/vacuum-hose-adapter.scad
@@ -247,7 +247,7 @@ module adapter(
         }
         else if(con[iStyle] == "kobalt")
         {
-          translate([0, 0, con[iLength]+con[iStopLength]])
+          translate([0, 0, con[iLength]])
           mirror ([0,0,1])
           KobaltConnector(
             innerEndDiameter = con[iInnerEndDiameter],
@@ -258,7 +258,7 @@ module adapter(
         }
         else if(con[iStyle] == "rigid_nxt" || con[iStyle] == "nxt")
         {
-          translate([0, 0, con[iLength]+con[iStopLength]])
+          translate([0, 0, con[iLength]])
           mirror ([0,0,1])
           RigidNXTConnector(
             outerStartDiameter = con[iOuterStartDiameter],

--- a/modules/vacuum-hose-adapter.scad
+++ b/modules/vacuum-hose-adapter.scad
@@ -179,6 +179,7 @@ module adapter(
             threadPitch = con[iThreadPitch],
             threadToothAngle = con[iThreadToothAngle],
             threadToothHeight = con[iThreadToothHeight],
+            threadProfile = con[iThreadProfile],
             help = help,
             $fn = $fn);
         }

--- a/modules/vacuum-hose-adapter.scad
+++ b/modules/vacuum-hose-adapter.scad
@@ -245,6 +245,17 @@ module adapter(
             help = help,
             $fn = $fn);
         }
+        else if(con[iStyle] == "kobalt")
+        {
+          translate([0, 0, con[iLength]+con[iStopLength]])
+          mirror ([0,0,1])
+          KobaltConnector(
+            innerEndDiameter = con[iInnerEndDiameter],
+            length = con[iLength],
+            wallThickness = con[iWallThickness],
+            help = help,
+            $fn = $fn);
+        }
         else if(con[iStyle] == "osvacm" || con[iStyle] == "osvacm32")
         {
           translate([0, 0, con[iLength]])

--- a/vacuum-hose-adapter.scad
+++ b/vacuum-hose-adapter.scad
@@ -16,7 +16,7 @@ include <modules/vacuum-hose-adapter.scad>
 End1_Wall_Thickness = 2; //0.01
 //The style of the end
 End1_Style="hose"; // [hose: Hose connector, mag: Magnetic Flange, flange: Flange, osvacm:osVAC Male, osvacf:osVAC Female]
-End1_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32,  makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug]
+End1_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32,  makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug, kobalt: Kobalt Saw Dust Outlet]
 // Is the measurement the adapter's outside or inside diameter?
 End1_Measurement = "outer"; //[inner, outer]
 // End 1 diameter of the adapter (mm, inch)
@@ -158,8 +158,12 @@ Transition_Base_Angle=0;
 /* [Connector 2] */
 //Wall thickness
 End2_Wall_Thickness = 2; //0.01
+<<<<<<< HEAD
 End2_Style="hose"; // [hose: Hose connector, mag: Magnetic Flange, flange: Flange, nozzle: Nozzle attachement, osvacm:osVAC Male, osvacf:osVAC Female, none: None]
 End2_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32,  makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug]
+=======
+End2_Style="hose"; // [mag: Magnetic Flange, flange: Flange, hose: Hose connector, nozzle: Nozzle attachement, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacm:osVAC Male, osvacf32:osVAC F32,osvacf:osVAC Female, makita_male: Makita Quick connect Male connector, kobalt: Kobalt Saw Dust Outlet, none: None]
+>>>>>>> f855436 (feat(connectors): add Kobalt saw dust outlet connector module)
 // Is the measurement the adapter's outside or inside diameter?
 End2_Measurement = "outer"; //[inner, outer]
 // End 2 diameter of the adapter (mm, inch)

--- a/vacuum-hose-adapter.scad
+++ b/vacuum-hose-adapter.scad
@@ -16,7 +16,7 @@ include <modules/vacuum-hose-adapter.scad>
 End1_Wall_Thickness = 2; //0.01
 //The style of the end
 End1_Style="hose"; // [hose: Hose connector, mag: Magnetic Flange, flange: Flange, osvacm:osVAC Male, osvacf:osVAC Female]
-End1_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32,  makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug, kobalt: Kobalt Saw Dust Outlet]
+End1_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32, makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug, kobalt: Kobalt Saw Dust Outlet, rigid_nxt: Rigid NXT Vac Hose]
 // Is the measurement the adapter's outside or inside diameter?
 End1_Measurement = "outer"; //[inner, outer]
 // End 1 diameter of the adapter (mm, inch)
@@ -159,11 +159,15 @@ Transition_Base_Angle=0;
 //Wall thickness
 End2_Wall_Thickness = 2; //0.01
 <<<<<<< HEAD
+<<<<<<< HEAD
 End2_Style="hose"; // [hose: Hose connector, mag: Magnetic Flange, flange: Flange, nozzle: Nozzle attachement, osvacm:osVAC Male, osvacf:osVAC Female, none: None]
 End2_Specialised_Style="disabled"; // [disabled:Disabled, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacf32:osVAC F32,  makita_male: Makita Quick connect Male connector, bosch_sander: Bosch orbital sander, festoolcleanteclug: Festool Cleantec Lug]
 =======
 End2_Style="hose"; // [mag: Magnetic Flange, flange: Flange, hose: Hose connector, nozzle: Nozzle attachement, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacm:osVAC Male, osvacf32:osVAC F32,osvacf:osVAC Female, makita_male: Makita Quick connect Male connector, kobalt: Kobalt Saw Dust Outlet, none: None]
 >>>>>>> f855436 (feat(connectors): add Kobalt saw dust outlet connector module)
+=======
+End2_Style="hose"; // [mag: Magnetic Flange, flange: Flange, hose: Hose connector, nozzle: Nozzle attachement, dyson: Dyson connector, camlock: CAMLOCK connetor, dw735: Dewalt DW735x, centec_female: Cen-Tec quick female connect, centec_male: Cen-Tec quick male connect, osvacm32:osVAC M32, osvacm:osVAC Male, osvacf32:osVAC F32,osvacf:osVAC Female, makita_male: Makita Quick connect Male connector, kobalt: Kobalt Saw Dust Outlet, rigid_nxt: Rigid NXT Vac Hose, none: None]
+>>>>>>> d73a8cc (feat(connectors): add Rigid NXT shop vac hose connector module)
 // Is the measurement the adapter's outside or inside diameter?
 End2_Measurement = "outer"; //[inner, outer]
 // End 2 diameter of the adapter (mm, inch)


### PR DESCRIPTION
## Summary
This PR introduces two new vacuum hose connector modules and supporting agent documentation:

- **Kobalt saw dust outlet connector module** (`connector_kobalt.scad`): Adds support for Kobalt saw dust outlet female sockets with recessed ring channels.
- **Rigid NXT shop vac hose connector module** (`connector_rigid_nxt.scad`): Adds support for Rigid NXT shop vac hose connectors with locking ridges.
- **Documentation & Agent Rules**: Added `AGENTS.md`, integration guide, and Cursor MDC rules for working with the library.

## Commits Included
- `feat(connectors): add Rigid NXT shop vac hose connector module`
- `feat(connectors): add Kobalt saw dust outlet connector module`
- `docs: add AGENTS.md, integration guide, and Cursor MDC rules`