### PR TITLE
Fix lock bump regression in BayonetSlotConnector

### DIFF
--- a/modules/module_twist_lock_hose.scad
+++ b/modules/module_twist_lock_hose.scad
@@ -175,6 +175,7 @@ module BayonetSlotConnector(
 
   cutoutArcLength = lockAngle/180*PI*(id/2+slotDepth);
 
+  union(){
   difference(){
     //main pipe
     pipe(
@@ -218,6 +219,15 @@ module BayonetSlotConnector(
         }
       }
     }
+  }
+
+  //it creates the bump to produce the lock
+  for(i = [0:slotCount-1])
+    rotate([0,0,i*360/slotCount+lockAngle/4])
+    translate([0,0,slotAxialHeight-slotAxialLength-slotDepth])
+      rotate_extrude(angle=lockAngle/2)
+        translate([slotFaceRadius-slotDepth+lockBumpDepth,0])
+          square([slotDepth,slotAxialLength+slotDepth]);
   }
 
   HelpTxt("BayonetSlotConnector",[


### PR DESCRIPTION
**Problem:** `BayonetSlotConnector` never generates the lock bump, so every female connector it builds has a plain full-depth channel and no twist lock. A male can be inserted and rotated, but nothing retains it. This affects `osVacFemaleConnector` (asks for a 0.40mm bump) and `FestoolCleantecSlotConnector` (asks for 0.10mm) — both were silently getting none.

**Cause:** The module accepts `lockBumpDepth`, asserts on it, and reports it in `HelpTxt`, but never references it in the geometry. It looks like it was missed when `connector_osvac` was refactored onto this module in ce1cc0c — before that commit, `osVacFemaleConnector` built the bump itself by cutting the lock pocket shallower than the channel:

```scad
translate([cutoutRadius-(cutoutDepthx*2),0,0])
square([cutoutDepthx+cutoutBumpDepthx, cutoutHeight*2], center=false);
```

That reaches `cutoutRadius - cutoutDepthx + cutoutBumpDepthx` = r 20.70 while the main channel cuts to r 21.10, leaving 0.40mm of material.

**Fix:** Restores the same result, but adds the bump back rather than cutting shallower, since the slots are now built as a union of cutters. Placement and size are unchanged from the original: `lockAngle/2` wide, starting at `lockAngle/4`.

**Verification:** osVAC F32, section through the lock channel at z=24. Before, the floor is flat at the slot depth all the way round. After, it rises to the detent diameter across the bump.


| | measured | nominal |
|---|---|---|
| channel floor | Ø42.21 | 42.20 |
| bump | Ø41.42 | 41.40 |
| bump height | 0.399 | 0.40 |

Festool renders clean at its lighter 0.10mm setting.

**Notes:**
1. All 15 styles in `test-render.ps1` render locally with no warnings or errors.
2. `combined/` is not regenerated here, matching other PRs.
3. No API change — `lockBumpDepth` already existed with a 1.6 default, so existing callers get the geometry they were already asking for.
4. `pr-test` fails, but identically on unmodified `main` — I checked with a comment-only probe branch and got the same 7 files. Pre-existing and unrelated; happy to raise it separately.
5. Full disclosure: this was written with Claude's help, found while working on adapters for my tools, that did not fit well with published STLs I had printed